### PR TITLE
Create public release

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ Converts a captured H.264 video into a series of JPEG frames. Objects can then b
 * Mount H.264 videos dataset to `/mnt/video`
 * Mount an output path for analyzed videos to `/mnt/analysis`
 
+## Troubles
+
+### PIP: Firebase-Admin SegFault
+
+Upgrade pip: `pip install --upgrade pip`
+
+### TensorFlow: Core Dump
+
+Verify CPU has AVX extensions: `cat /proc/cpuinfo` or whatever is right for windows.
+
+You might be compiling on your own! https://www.tensorflow.org/install/source
+
+Set aside about 24 hours for the compilation to complete.
+
 # Using the Local Pipeline
 
 ```
@@ -45,6 +59,20 @@ Open a browser to http://localhost:1234
 Chairs of the migratory variety...
 
 ![example](image.png)
+## Building for Public Release (Production)
+
+```
+# Compile and minify JS to public/
+npm run build
+# Copy index.html to public/
+npm run package
+# Run a server to preview the compiled site (required docker)
+npm run preview # http://localhost:8081 has compiled site
+# Deploy to Firebase Hosting
+npm run deploy
+```
+
+Optionally, clean-up cruft in `public/` with `npm run clean`.
 
 # Plans
 

--- a/ingest_to_firestore.py
+++ b/ingest_to_firestore.py
@@ -50,5 +50,6 @@ def show_documents():
 
 
 if __name__ == "__main__":
+    print(f"Ingesting {sys.argv[1]}")
     create_document(sys.argv[1])
     # show_documents()

--- a/package.json
+++ b/package.json
@@ -5,7 +5,12 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "parcel index.html"
+    "start": "parcel index.html",
+    "clean": "rm -rf public/*",
+    "build": "parcel build --out-dir public index.js src/*.js src/**/*.js",
+    "package": "cp index.html public/",
+    "preview": "docker run --rm --name pi-garage-cam -p 8081:80 -v $(pwd)/public:/usr/share/nginx/html nginx",
+    "deploy": "firebase deploy"
   },
   "author": "",
   "license": "ISC",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ opencv-python
 cvlib
 mxnet
 tensorflow
+firebase-admin


### PR DESCRIPTION
Add `build`, `package`, and `deploy` tasks to `package.json`.

The application can now be compiled to `public/` and then deployed to Firebase Hosting at https://pi-garage-6000-291113.firebaseapp.com/ .

Updated the documentation with steps to build, package, and preview the application before describing how to deploy to a public URL.