### PR TITLE
Allow FPS in getFrames

### DIFF
--- a/getFrames.sh
+++ b/getFrames.sh
@@ -3,6 +3,10 @@
 # Example: ./getFrames /mnt/video/camera1-20200920T225214.1600667534.h264
 set -e
 VIDEO=$(basename $1)
+
+# 1/2 of recording FPS (30)
+FPS=${2:-15}
+
 CAMERA=$(echo $VIDEO | cut -d-  -f1)
 DATE=$(echo $VIDEO | cut -d-  -f2 | cut -d. -f1-2)
 
@@ -10,5 +14,10 @@ OUTPATH=/mnt/analysis/$CAMERA/$DATE
 
 echo "Creating $OUTPATH"
 mkdir -p $OUTPATH
-
-ffmpeg -i $1 -qscale:4 2 $OUTPATH/%04d.jpg
+echo "Decoding at $FPS"
+# Decode at 15 FPS
+ffmpeg \
+  -i $1 \
+  -qscale:4 2 \
+  -vf fps=fps=$FPS \
+  $OUTPATH/%04d.jpg


### PR DESCRIPTION
Allow the operator to pass the FPS to reduce a video to as a positional argument to `getFrames.sh`